### PR TITLE
bug: change basename and homepage so that 404 routes redirect

### DIFF
--- a/shopping-cart/package.json
+++ b/shopping-cart/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "shopping-cart",
-	"homepage": "https://justwavethings.github.io/shop/",
+	"homepage": "https://justwavethings.github.io/shop",
 	"version": "0.1.0",
 	"private": true,
 	"type": "module",

--- a/shopping-cart/src/App.js
+++ b/shopping-cart/src/App.js
@@ -37,7 +37,7 @@ const router = createBrowserRouter(
 		</Route>
 	),
 	{
-		basename: '/shop/'
+		basename: '/shop'
 	}
 );
 


### PR DESCRIPTION
This PR:

- after confirming functionality locally, adjust trailing / in basename and homepage to see if this is what is causing the 404 route to not load.