### PR TITLE
bug: wont-fix gh-pages 404 issue

### DIFF
--- a/shopping-cart/src/App.js
+++ b/shopping-cart/src/App.js
@@ -30,6 +30,7 @@ const router = createBrowserRouter(
 				path="cart"
 				element={<Cart />}
 			/>
+			{/* This catch-all route DOES NOT WORK in a GH pages deployment due to how GH interacts with the CRA react app. Given that CRA is now deprecated, and the solution to the issue is to use HashRouter, which is strongly discouraged to use, I am going to leave this 'as-is' */}
 			<Route
 				path="*"
 				element={<NotFound />}

--- a/shopping-cart/src/index.js
+++ b/shopping-cart/src/index.js
@@ -3,11 +3,9 @@ import ReactDOM from 'react-dom/client';
 import './index.css';
 import App from './App.js';
 
-
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
-  <React.StrictMode>
-    <App />
-  </React.StrictMode>
+	<React.StrictMode>
+		<App />
+	</React.StrictMode>
 );
-


### PR DESCRIPTION
This PR:

- Returns project back to working state minus custom 404 route.  Given that CRA is deprecated, and the solution to overcome the issue with react-router is to use `HashRouter` which even in the docs is not advised to do. Given that the 404 route works locally, I am confident that I could deploy to another provider and have that full functionality if I made this a portfolio project.